### PR TITLE
change how dependency can be created

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ env:
 jobs:
   run_tests:
     name: Run tests
+    if: github.ref == 'refs/heads/main'
     runs-on: macos-latest
     steps:
       - name: Checkout repository
@@ -32,20 +33,141 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
+      - name: Check
+        run: ./gradlew detekt
+
       - name: Build project
         run: ./gradlew build
+
+  build_xcframework:
+    name: Build XCFramework
+    runs-on: macos-latest
+    needs: [run_tests]
+    outputs:
+      sha256: ${{ steps.calculate_checksum.outputs.sha256 }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build XCFramework
+        run: ./gradlew assembleJsonLogicKMPXCFramework
+
+      - name: Zip XCFramework
+        run: |
+          mv "build/XCFrameworks/release/${{ env.xcframework_name }}" .
+          zip -r "${{ env.xcframework_zip_name }}" "${{ env.xcframework_name }}" LICENSE
+
+      - name: Calculate checksum
+        id: calculate_checksum
+        run: |
+          XCFRAMEWORK_SHA256=$(shasum -a 256 JsonLogicKMP.xcframework.zip | awk '{ print $1 }')
+          echo "::set-output name=sha256::$XCFRAMEWORK_SHA256"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: "${{ env.xcframework_artifact_key }}"
+          path: "${{ env.xcframework_zip_name }}"
+          if-no-files-found: error
+          retention-days: 1
+
+  create_release_branch:
+    name: Create release branch and bump version
+    runs-on: ubuntu-latest
+    needs: [run_tests, build_xcframework]
+    outputs:
+      tag: ${{ steps.bump.outputs.next_tag }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get next tag
+        id: "bump"
+        uses: allegro-actions/next-version@v1
+        with:
+          prefix: ""
+          force: ${{ github.event.inputs.next_version }}
+
+      - name: Change version in podspec file
+        run: |
+          VERSION=${{ steps.bump.outputs.next_tag }}
+          sed -i -e "s/spec.version.*= .*$/spec\.version      = \"$VERSION\"/g" "${{ env.podspec_name }}"
+
+      - name: Change SHA256 in podspec file
+        run: |
+          XCFRAMEWORK_SHA256="${{ needs.build_xcframework.outputs.sha256 }}"
+          sed -i -e "s/:sha256.*=>.*$/:sha256 => \"$XCFRAMEWORK_SHA256\"/g" "${{ env.podspec_name }}"
+
+      - name: Setup git config
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+
+      - name: Commit and push version bump
+        run: |
+          VERSION=${{ steps.bump.outputs.next_tag }}
+          BRANCH_NAME=release/$VERSION
+          git checkout -b $BRANCH_NAME
+          git add "${{ env.podspec_name }}"
+          git commit -m "Bump version to: $VERSION"
+          git push -u origin $BRANCH_NAME
+          git tag $VERSION
+          git push origin tag $VERSION
+
+      - name: Create pull request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: "release/${{ steps.bump.outputs.next_tag }}"
+          destination_branch: "main"
+          pr_title: "Bump version to ${{ steps.bump.outputs.next_tag }}"
+          pr_body: "## Note:\n
+            * This pull request is created by workflow 🤖\n
+            ## What:\n
+            * bump version to ${{ steps.bump.outputs.next_tag }}\n
+            * commit tag\n
+            * updated podspec file\n
+            ## Why:\n
+            * New release"
+          pr_allow_empty: false
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_github_release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: [run_tests, build_xcframework, create_release_branch]
+    steps:
+      - name: Download XCFramework
+        uses: actions/download-artifact@v2
+        with:
+          name: "${{ env.xcframework_artifact_key }}"
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: "${{ needs.create_release_branch.outputs.tag }}"
+          name: "Release ${{ needs.create_release_branch.outputs.tag }}"
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: "${{ env.xcframework_zip_name }}"
 
   publish_to_maven:
     name: Publish to maven
     runs-on: macos-latest
     needs:
       [
-        run_tests
+        run_tests,
+        build_xcframework,
+        create_release_branch,
+        create_github_release,
       ]
     steps:
       - uses: actions/checkout@v2
         with:
-            fetch-depth: 0
+          ref: "${{ needs.create_release_branch.outputs.tag }}"
+          fetch-depth: 0
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -64,3 +186,24 @@ jobs:
           GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PRIVATE_KEY_PASSWORD: ${{ secrets.GPG_PRIVATE_KEY_PASSWORD }}
+
+  publish_to_cocoapods:
+    name: Publish to cocoadpods
+    needs:
+      [
+        run_tests,
+        build_xcframework,
+        create_release_branch,
+        create_github_release,
+      ]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: "${{ needs.create_release_branch.outputs.tag }}"
+
+      - name: Publish to cocoadpods
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: |
+          pod trunk push "${{ env.podspec_name }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,6 @@ env:
 jobs:
   run_tests:
     name: Run tests
-    if: github.ref == 'refs/heads/main'
     runs-on: macos-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,9 +32,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      - name: Check
-        run: ./gradlew detekt
-
       - name: Build project
         run: ./gradlew build
 
@@ -47,6 +44,8 @@ jobs:
       ]
     steps:
       - uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,135 +39,15 @@ jobs:
       - name: Build project
         run: ./gradlew build
 
-  build_xcframework:
-    name: Build XCFramework
-    runs-on: macos-latest
-    needs: [run_tests]
-    outputs:
-      sha256: ${{ steps.calculate_checksum.outputs.sha256 }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Build XCFramework
-        run: ./gradlew assembleJsonLogicKMPXCFramework
-
-      - name: Zip XCFramework
-        run: |
-          mv "build/XCFrameworks/release/${{ env.xcframework_name }}" .
-          zip -r "${{ env.xcframework_zip_name }}" "${{ env.xcframework_name }}" LICENSE
-
-      - name: Calculate checksum
-        id: calculate_checksum
-        run: |
-          XCFRAMEWORK_SHA256=$(shasum -a 256 JsonLogicKMP.xcframework.zip | awk '{ print $1 }')
-          echo "::set-output name=sha256::$XCFRAMEWORK_SHA256"
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: "${{ env.xcframework_artifact_key }}"
-          path: "${{ env.xcframework_zip_name }}"
-          if-no-files-found: error
-          retention-days: 1
-
-  create_release_branch:
-    name: Create release branch and bump version
-    runs-on: ubuntu-latest
-    needs: [run_tests, build_xcframework]
-    outputs:
-      tag: ${{ steps.bump.outputs.next_tag }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Get next tag
-        id: "bump"
-        uses: allegro-actions/next-version@v1
-        with:
-          prefix: ""
-          force: ${{ github.event.inputs.next_version }}
-
-      - name: Change version in podspec file
-        run: |
-          VERSION=${{ steps.bump.outputs.next_tag }}
-          sed -i -e "s/spec.version.*= .*$/spec\.version      = \"$VERSION\"/g" "${{ env.podspec_name }}"
-
-      - name: Change SHA256 in podspec file
-        run: |
-          XCFRAMEWORK_SHA256="${{ needs.build_xcframework.outputs.sha256 }}"
-          sed -i -e "s/:sha256.*=>.*$/:sha256 => \"$XCFRAMEWORK_SHA256\"/g" "${{ env.podspec_name }}"
-
-      - name: Setup git config
-        run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
-
-      - name: Commit and push version bump
-        run: |
-          VERSION=${{ steps.bump.outputs.next_tag }}
-          BRANCH_NAME=release/$VERSION
-          git checkout -b $BRANCH_NAME
-          git add "${{ env.podspec_name }}"
-          git commit -m "Bump version to: $VERSION"
-          git push -u origin $BRANCH_NAME
-          git tag $VERSION
-          git push origin tag $VERSION
-
-      - name: Create pull request
-        uses: repo-sync/pull-request@v2
-        with:
-          source_branch: "release/${{ steps.bump.outputs.next_tag }}"
-          destination_branch: "main"
-          pr_title: "Bump version to ${{ steps.bump.outputs.next_tag }}"
-          pr_body: "## Note:\n
-            * This pull request is created by workflow 🤖\n
-            ## What:\n
-            * bump version to ${{ steps.bump.outputs.next_tag }}\n
-            * commit tag\n
-            * updated podspec file\n
-            ## Why:\n
-            * New release"
-          pr_allow_empty: false
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-  create_github_release:
-    name: Create GitHub release
-    runs-on: ubuntu-latest
-    needs: [run_tests, build_xcframework, create_release_branch]
-    steps:
-      - name: Download XCFramework
-        uses: actions/download-artifact@v2
-        with:
-          name: "${{ env.xcframework_artifact_key }}"
-
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: "${{ needs.create_release_branch.outputs.tag }}"
-          name: "Release ${{ needs.create_release_branch.outputs.tag }}"
-          draft: false
-          prerelease: false
-          generate_release_notes: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-          files: "${{ env.xcframework_zip_name }}"
-
   publish_to_maven:
     name: Publish to maven
     runs-on: macos-latest
     needs:
       [
-        run_tests,
-        build_xcframework,
-        create_release_branch,
-        create_github_release,
+        run_tests
       ]
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: "${{ needs.create_release_branch.outputs.tag }}"
-          fetch-depth: 0
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -186,24 +66,3 @@ jobs:
           GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PRIVATE_KEY_PASSWORD: ${{ secrets.GPG_PRIVATE_KEY_PASSWORD }}
-
-  publish_to_cocoapods:
-    name: Publish to cocoadpods
-    needs:
-      [
-        run_tests,
-        build_xcframework,
-        create_release_branch,
-        create_github_release,
-      ]
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: "${{ needs.create_release_branch.outputs.tag }}"
-
-      - name: Publish to cocoadpods
-        env:
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        run: |
-          pod trunk push "${{ env.podspec_name }}"

--- a/src/commonMain/kotlin/JsonLogicEngine.kt
+++ b/src/commonMain/kotlin/JsonLogicEngine.kt
@@ -36,6 +36,9 @@ interface JsonLogicEngine {
 
     companion object {
         val instance: JsonLogicEngine by lazy { CommonJsonLogicEngine() }
+
+        fun create(): JsonLogicEngine = CommonJsonLogicEngine()
+
         internal val standardOperations: Map<String, (Any?, Any?) -> Any?> = mapOf(
             // data
             Var.operation,


### PR DESCRIPTION
## What:
add `create()` function that allows to create JsonLogicEngine instance

## Why:
using JsonLogicEngine.instance probably forces us to declare this library as api dependency which is considered a bad practice.
