### PR TITLE
Substring operation fix

### DIFF
--- a/core/src/commonMain/kotlin/operations/string/Substr.kt
+++ b/core/src/commonMain/kotlin/operations/string/Substr.kt
@@ -26,7 +26,7 @@ object Substr : StandardLogicOperation, StringUnwrapStrategy {
         }.getOrNull().orEmpty()
     }
 
-    private fun String.fromStartIndexToEnd(startIndex: Int) = if (startIndex > 0) {
+    private fun String.fromStartIndexToEnd(startIndex: Int) = if (startIndex >= 0) {
         substring(startIndex)
     } else {
         substring(length + startIndex)

--- a/core/src/commonTest/kotlin/operations/string/SubstrTest.kt
+++ b/core/src/commonTest/kotlin/operations/string/SubstrTest.kt
@@ -111,6 +111,26 @@ class SubstrTest : FunSpec({
                     expression = mapOf("substr" to listOf("2.0")),
                     resultValue = "2.0"
                 ),
+                Successful(
+                    expression = mapOf("substr" to listOf(mapOf("var" to "A"),0)),
+                    data = mapOf("A" to "x"),
+                    resultValue = "x"
+                ),
+                Successful(
+                    expression = mapOf("substr" to listOf(mapOf("var" to "A"),0)),
+                    data = mapOf("A" to ""),
+                    resultValue = ""
+                ),
+                Successful(
+                    expression = mapOf("substr" to listOf(mapOf("var" to "A"),0)),
+                    data = mapOf("A" to "xx"),
+                    resultValue = "xx"
+                ),
+                Successful(
+                    expression = mapOf("substr" to listOf(mapOf("var" to "A"), 0, 0)),
+                    data = mapOf("A" to "x"),
+                    resultValue = ""
+                ),
             )
         )
     }


### PR DESCRIPTION
## What:
<!--- Describe your changes in detail. -->
* Minor substring operation fix

## Why:
<!--- Why is this change required? What problem does it solve? -->
* When start index(without chars count) was equal to 0 algorithm treated like: get a substring in reversed order. 

## Example:
<!--- Share some code snippets to show the idea in action. -->
* [Last 4 unit test cases](https://github.com/allegro/json-logic-kmp/compare/substring-0-index-inclusion?expand=1#diff-725456c3586fc2a97424eb1fc4d89731d7702a99d9ab9a9684c6882af25e9a0eR114-R133)
![image](https://user-images.githubusercontent.com/84186160/163357557-bae203ce-a140-45ef-a160-88a24a942be8.png)
