### PR TITLE
Skip publishing iOS targets to maven

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -179,7 +179,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Publish to maven central
-        run: ./gradlew core:publishToSonatype operations-api:publishToSonatype operations-stdlib:publishToSonatype closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew publishJvmPublicationToSonatypeRepository publishKotlinMultiplatformPublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}


### PR DESCRIPTION
## What:
<!--- Describe your changes in detail. -->
* Skip publishing iOS targets to maven

## Why:
<!--- Why is this change required? What problem does it solve? -->
* We don't need iOS targets on maven

## Example:
<!--- Share some code snippets to show the idea in action. -->
* Tested with command "./gradlew publishJvmPublicationToMavenLocal publishKotlinMultiplatformPublicationToMavenLocal"
