### PR TITLE
Disable args autowrapping

### DIFF
--- a/core/src/commonMain/kotlin/evaluation/CommonLogicEvaluator.kt
+++ b/core/src/commonMain/kotlin/evaluation/CommonLogicEvaluator.kt
@@ -22,13 +22,13 @@ internal class CommonLogicEvaluator(private val operations: LogicOperations) : L
         val operator = logic.keys.firstOrNull()
         val values = logic[operator]
         return if (operations.functionalOperations.keys.contains(operator)) {
-            operations.functionalOperations[operator]?.evaluateLogic(values.asList, data, this)
+            operations.functionalOperations[operator]?.evaluateLogic(values, data, this)
         } else {
             operations.standardOperations.getOperation(operator).evaluateLogic(when (values) {
                 is List<*> -> values.map { executeExpression(it, data) }
                 is Map<*, *> -> executeExpression(values, data)
-                else -> executeExpression(listOf(values), data)
-            }.asList,data)
+                else -> executeExpression(values, data)
+            }, data)
         }
     }
 

--- a/core/src/commonMain/kotlin/operations/data/Missing.kt
+++ b/core/src/commonMain/kotlin/operations/data/Missing.kt
@@ -1,12 +1,13 @@
 package operations.data
 
 import operation.StandardLogicOperation
+import utils.asList
 
 internal object Missing : StandardLogicOperation {
     override fun evaluateLogic(expression: Any?, data: Any?): List<Any?> {
-        return (expression as? List<Any?>)?.mapNotNull {
+        return expression.asList.mapNotNull {
             it.takeIf { Var.evaluateLogic(it, data).isNullOrEmptyString() }
-        }.orEmpty()
+        }
     }
 
     private fun Any?.isNullOrEmptyString() = this == null || (this is String && this.isEmpty())

--- a/core/src/commonMain/kotlin/operations/data/Var.kt
+++ b/core/src/commonMain/kotlin/operations/data/Var.kt
@@ -2,12 +2,13 @@ package operations.data
 
 import operation.StandardLogicOperation
 import operations.data.unwrap.ValueFetchingUnwrapStrategy
+import utils.asList
 import utils.intOrZero
 import utils.secondOrNull
 
 internal object Var : StandardLogicOperation, ValueFetchingUnwrapStrategy {
     override fun evaluateLogic(expression: Any?, data: Any?): Any? =
-        unwrapDataKeys(expression)?.fetchValueOrDefault(expression, data)
+        unwrapDataKeys(expression.asList)?.fetchValueOrDefault(expression, data)
 
     private fun List<String>.fetchValueOrDefault(expression: Any?, data: Any?): Any? {
         val value = if (isNotEmpty()) {

--- a/core/src/commonTest/kotlin/operations/array/FilterTest.kt
+++ b/core/src/commonTest/kotlin/operations/array/FilterTest.kt
@@ -53,6 +53,15 @@ class FilterTest : FunSpec({
             TestInput(
                 expression = mapOf(
                     "filter" to listOf(
+                        5,
+                        mapOf(">=" to listOf(mapOf("var" to ""), 2))
+                    )
+                ),
+                result = JsonLogicResult.Success(emptyList<String>())
+            ),
+            TestInput(
+                expression = mapOf(
+                    "filter" to listOf(
                         listOf(1, 2, 3, 4, 5),
                         listOf(1, 2, 3, 4, 5),
                         mapOf(">=" to listOf(mapOf("var" to ""), 2))

--- a/operations-stdlib/src/commonMain/kotlin/Reverse.kt
+++ b/operations-stdlib/src/commonMain/kotlin/Reverse.kt
@@ -1,12 +1,12 @@
 import operation.StandardLogicOperation
-import utils.asList
 
 object Reverse : StandardLogicOperation {
     override fun evaluateLogic(expression: Any?, data: Any?): Any? {
-        return when (val firstItem = expression.asList.firstOrNull()) {
-            is String -> firstItem.reversed()
-            is List<*> -> firstItem.reversed()
+        return when (expression) {
+            is String -> expression.reversed()
+            is List<*> -> expression.reversed()
             else -> null
+
         }
     }
 }

--- a/operations-stdlib/src/commonMain/kotlin/array/Distinct.kt
+++ b/operations-stdlib/src/commonMain/kotlin/array/Distinct.kt
@@ -5,11 +5,5 @@ import utils.asList
 import utils.isSingleNullList
 
 object Distinct : StandardLogicOperation {
-    override fun evaluateLogic(expression: Any?, data: Any?): Any? {
-        return when (val firstItem = expression.asList.firstOrNull()) {
-            is List<*> -> firstItem.distinct()
-            firstItem.isSingleNullList() -> null
-            else -> null
-        }
-    }
+    override fun evaluateLogic(expression: Any?, data: Any?): Any? = (expression as? List<*>)?.distinct()
 }

--- a/operations-stdlib/src/commonMain/kotlin/array/Size.kt
+++ b/operations-stdlib/src/commonMain/kotlin/array/Size.kt
@@ -5,12 +5,5 @@ import utils.asList
 import utils.isSingleNullList
 
 object Size : StandardLogicOperation {
-    override fun evaluateLogic(expression: Any?, data: Any?): Any? {
-        return when (val firstItem = expression.asList.firstOrNull()) {
-            firstItem.isSingleNullList() -> null
-            is Map<*, *> -> firstItem.size
-            is List<*> -> firstItem.size
-            else -> null
-        }
-    }
+    override fun evaluateLogic(expression: Any?, data: Any?): Any? = (expression as? List<*>)?.size
 }

--- a/operations-stdlib/src/commonMain/kotlin/array/Sort.kt
+++ b/operations-stdlib/src/commonMain/kotlin/array/Sort.kt
@@ -8,10 +8,10 @@ import utils.secondOrNull
 object Sort : StandardLogicOperation {
     override fun evaluateLogic(expression: Any?, data: Any?): Any? =
         with(expression.asList) {
-            val elementsToSort = firstOrNull()?.asList
-            val sortingMode = (secondOrNull() as? String).toSortOrder()
-
-            elementsToSort?.sortByMode(sortingMode)
+            (firstOrNull() as? List<*>)?.let { elementsToSort ->
+                val sortingMode = (secondOrNull() as? String).toSortOrder()
+                elementsToSort?.sortByMode(sortingMode)
+            }
         }
 
     private fun String?.toSortOrder() = when (this) {

--- a/operations-stdlib/src/commonMain/kotlin/array/Sort.kt
+++ b/operations-stdlib/src/commonMain/kotlin/array/Sort.kt
@@ -10,7 +10,7 @@ object Sort : StandardLogicOperation {
         with(expression.asList) {
             (firstOrNull() as? List<*>)?.let { elementsToSort ->
                 val sortingMode = (secondOrNull() as? String).toSortOrder()
-                elementsToSort?.sortByMode(sortingMode)
+                elementsToSort.sortByMode(sortingMode)
             }
         }
 

--- a/operations-stdlib/src/commonTest/kotlin/DropTest.kt
+++ b/operations-stdlib/src/commonTest/kotlin/DropTest.kt
@@ -23,13 +23,12 @@ class DropTest : FunSpec({
                 expression = mapOf(
                     operatorName to listOf(
                         mapOf(
-                            "reverse" to listOf(
+                            "reverse" to
                                 listOf(
                                     "element1",
                                     "element2",
                                     "element3"
                                 )
-                            )
                         ), 2, "first"
                     )
                 ),

--- a/operations-stdlib/src/commonTest/kotlin/ReverseTest.kt
+++ b/operations-stdlib/src/commonTest/kotlin/ReverseTest.kt
@@ -20,7 +20,7 @@ class ReverseTest : FunSpec({
             ),
             TestInput(
                 expression = mapOf(operatorName to listOf("apple")),
-                result = Success("elppa")
+                result = Success(listOf("apple"))
             ),
             TestInput(
                 expression = mapOf(operatorName to "12345"),
@@ -28,14 +28,18 @@ class ReverseTest : FunSpec({
             ),
             TestInput(
                 expression = mapOf(operatorName to listOf(listOf(1, 2, 3, 4, 5))),
-                result = Success(listOf(5,4,3,2,1))
+                result = Success(listOf(listOf(1, 2, 3, 4, 5)))
             ),
             TestInput(
                 expression = mapOf(operatorName to listOf(listOf("element1", "element2", "element3"))),
+                result = Success(listOf(listOf("element1", "element2", "element3")))
+            ),
+            TestInput(
+                expression = mapOf(operatorName to listOf("element1", "element2", "element3")),
                 result = Success(listOf("element3", "element2", "element1"))
             ),
             TestInput(
-                expression = mapOf(operatorName to listOf(mapOf("var" to "key"))),
+                expression = mapOf(operatorName to mapOf("var" to "key")),
                 data = mapOf("key" to listOf(1, 2, 3, 4, 5)),
                 result = Success(listOf(5,4,3,2,1))
             ),
@@ -62,7 +66,7 @@ class ReverseTest : FunSpec({
             ),
             TestInput(
                 expression = mapOf(operatorName to emptyList<Any>()),
-                result = Failure.NullResult
+                result = Success(emptyList<Any>())
             ),
         )
         // given

--- a/operations-stdlib/src/commonTest/kotlin/array/DistinctTest.kt
+++ b/operations-stdlib/src/commonTest/kotlin/array/DistinctTest.kt
@@ -16,10 +16,18 @@ class DistinctTest : FunSpec({
         ts = listOf(
             TestInput(
                 expression = mapOf("distinct" to listOf(listOf(listOf("apple"), listOf("apple"), listOf("pineapple")))),
+                result = Success(listOf(listOf(listOf("apple"), listOf("apple"), listOf("pineapple"))))
+            ),
+            TestInput(
+                expression = mapOf("distinct" to listOf(listOf("apple"), listOf("apple"), listOf("pineapple"))),
                 result = Success(listOf(listOf("apple"), listOf("pineapple")))
             ),
             TestInput(
                 expression = mapOf("distinct" to listOf(listOf(listOf(null), listOf(null), listOf(null)))),
+                result = Success(listOf(listOf(listOf(null), listOf(null), listOf(null))))
+            ),
+            TestInput(
+                expression = mapOf("distinct" to listOf(listOf(null), listOf(null), listOf(null))),
                 result = Success(listOf(listOf(null)))
             ),
             TestInput(
@@ -28,14 +36,18 @@ class DistinctTest : FunSpec({
             ),
             TestInput(
                 expression = mapOf("distinct" to listOf("true", true, 0, 1)),
-                result = Failure.NullResult
-            ),
-            TestInput(
-                expression = mapOf("distinct" to listOf(listOf("true", true, 0, 1))),
                 result = Success(listOf("true", true, 0, 1))
             ),
             TestInput(
+                expression = mapOf("distinct" to listOf(listOf("true", true, 0, 1))),
+                result = Success(listOf(listOf("true", true, 0, 1)))
+            ),
+            TestInput(
                 expression = mapOf("distinct" to listOf(listOf(null, null, null, null))),
+                result = Success(listOf(listOf(null, null, null, null)))
+            ),
+            TestInput(
+                expression = mapOf("distinct" to listOf(null, null, null, null)),
                 result = Success(listOf(null))
             ),
             TestInput(
@@ -49,6 +61,17 @@ class DistinctTest : FunSpec({
                     )
                 ),
                 data = mapOf("fruit" to null, "vegetable" to null, "mushroom" to true),
+                result = Success(listOf(listOf(null, null, true)))
+            ),
+            TestInput(
+                expression = mapOf(
+                    "distinct" to listOf(
+                        mapOf("var" to "fruit"),
+                        mapOf("var" to "vegetable"),
+                        mapOf("var" to "mushroom")
+                    )
+                ),
+                data = mapOf("fruit" to null, "vegetable" to null, "mushroom" to true),
                 result = Success(listOf(null, true))
             ),
             TestInput(
@@ -57,7 +80,7 @@ class DistinctTest : FunSpec({
             ),
             TestInput(
                 expression = mapOf("distinct" to emptyList<Any>()),
-                result = Failure.NullResult
+                result = Success(emptyList<Any>())
             ),
             TestInput(
                 expression = mapOf("distinct" to null),
@@ -68,27 +91,39 @@ class DistinctTest : FunSpec({
                 result = Failure.NullResult
             ),
             TestInput(
-                expression = mapOf("distinct" to emptyList<Any>()),
-                result = Failure.NullResult
+                expression = mapOf("distinct" to listOf(emptyList<Any>())),
+                result = Success(listOf(emptyList<Any>()))
             ),
             TestInput(
                 expression = mapOf("distinct" to listOf(null, mapOf("var" to ""))),
-                result = Failure.NullResult
+                result = Success(listOf(null, emptyMap<String, Any>()))
             ),
             TestInput(
                 expression = mapOf("distinct" to listOf(emptyList<String>(), mapOf("var" to ""))),
-                result = Success(emptyList<String>())
+                result = Success(listOf(emptyList<String>(), emptyMap<String, Any>()))
             ),
             TestInput(
                 expression = mapOf("distinct" to listOf(listOf(false, false), mapOf("var" to ""))),
-                result = Success(listOf(false))
+                result = Success(listOf(listOf(false, false), emptyMap<String, Any>()))
+            ),
+            TestInput(
+                expression = mapOf("distinct" to listOf(false, mapOf("var" to ""))),
+                result = Success(listOf(false, emptyMap<String, Any>()))
             ),
             TestInput(
                 expression = mapOf("distinct" to listOf(listOf(true, false), mapOf("var" to ""))),
-                result = Success(listOf(true, false))
+                result = Success(listOf(listOf(true, false), emptyMap<String, Any>()))
+            ),
+            TestInput(
+                expression = mapOf("distinct" to listOf(true, false, mapOf("var" to ""))),
+                result = Success(listOf(true, false, emptyMap<String, Any>()))
             ),
             TestInput(
                 expression = mapOf("distinct" to listOf(listOf(true, false))),
+                result = Success(listOf(listOf(true, false)))
+            ),
+            TestInput(
+                expression = mapOf("distinct" to listOf(true, false)),
                 result = Success(listOf(true, false))
             ),
             TestInput(
@@ -103,7 +138,7 @@ class DistinctTest : FunSpec({
                     )
                 ),
                 data = mapOf("integers" to listOf(1, 2, 3, 4, 5)),
-                result = Success(listOf(1, 3, 5))
+                result = Success(listOf(listOf(1, 3, 5), false))
             ),
             TestInput(
                 expression = mapOf(
@@ -112,19 +147,19 @@ class DistinctTest : FunSpec({
                         mapOf(">" to listOf(mapOf("var" to ""), 0))
                     )
                 ),
-                result = Success(listOf(-1, 1, 2, 3))
+                result = Success(listOf(listOf(-1, 1, 2, 3), false))
             ),
             TestInput(
                 expression = mapOf("distinct" to listOf(listOf(7, 7, 7), mapOf("==" to listOf(mapOf("var" to ""), 0)))),
-                result = Success(listOf(7))
+                result = Success(listOf(listOf(7, 7, 7), false))
             ),
             TestInput(
                 expression = mapOf("distinct" to listOf(listOf(3, 3), mapOf("===" to listOf(mapOf("var" to ""), 0)))),
-                result = Success(listOf(3))
+                result = Success(listOf(listOf(3, 3), false))
             ),
             TestInput(
                 expression = mapOf("distinct" to listOf(listOf(0, 1, 0), mapOf("!=" to listOf(mapOf("var" to ""), 0)))),
-                result = Success(listOf(0, 1))
+                result = Success(listOf(listOf(0, 1, 0), true))
             ),
             TestInput(
                 expression = mapOf(
@@ -133,7 +168,18 @@ class DistinctTest : FunSpec({
                         mapOf(">" to listOf(mapOf("var" to ""), 0))
                     )
                 ),
-                result = Success(listOf(-1, "b", "a", true))
+                result = Success(listOf(listOf(-1, "b", "a", true), false))
+            ),
+            TestInput(
+                expression = mapOf(
+                    "distinct" to mapOf(
+                        "merge" to listOf(
+                            listOf(-1, "b", "a", true),
+                            mapOf(">" to listOf(mapOf("var" to ""), 0))
+                        )
+                    )
+                ),
+                result = Success(listOf(-1, "b", "a", true, false))
             ),
             TestInput(
                 expression = mapOf(
@@ -142,7 +188,18 @@ class DistinctTest : FunSpec({
                         mapOf("<" to listOf(mapOf("var" to ""), 0))
                     )
                 ),
-                result = Success(listOf("strawberry", true, 2, 3))
+                result = Success(listOf(listOf("strawberry", true, 2, 3), false))
+            ),
+            TestInput(
+                expression = mapOf(
+                    "distinct" to mapOf(
+                        "merge" to listOf(
+                            listOf("strawberry", true, 2, 3),
+                            mapOf("<" to listOf(mapOf("var" to ""), 0))
+                        )
+                    )
+                ),
+                result = Success(listOf("strawberry", true, 2, 3, false))
             ),
             TestInput(
                 expression = mapOf(
@@ -151,7 +208,18 @@ class DistinctTest : FunSpec({
                         mapOf("==" to listOf(mapOf("var" to ""), "apple"))
                     )
                 ),
-                result = Success(listOf("banana", "apple"))
+                result = Success(listOf(listOf("banana", "apple"), false))
+            ),
+            TestInput(
+                expression = mapOf(
+                    "distinct" to mapOf(
+                        "merge" to listOf(
+                            listOf("banana", "apple"),
+                            mapOf("==" to listOf(mapOf("var" to ""), "apple"))
+                        )
+                    )
+                ),
+                result = Success(listOf("banana", "apple", false))
             ),
             TestInput(
                 expression = mapOf(
@@ -161,11 +229,23 @@ class DistinctTest : FunSpec({
                     )
                 ),
                 data = mapOf("fruits" to listOf("apple", "banana", "pineapple")),
-                result = Success(listOf("apple", "banana", "pineapple"))
+                result = Success(listOf(listOf("apple", "banana", "pineapple"), false))
             ),
             TestInput(
                 expression = mapOf(
-                    "distinct" to listOf(listOf("a", 3, "c"))
+                    "distinct" to mapOf(
+                        "merge" to listOf(
+                            mapOf("var" to "fruits"),
+                            mapOf("==" to listOf(mapOf("var" to ""), "pineapple"))
+                        )
+                    )
+                ),
+                data = mapOf("fruits" to listOf("apple", "banana", "pineapple")),
+                result = Success(listOf("apple", "banana", "pineapple", false))
+            ),
+            TestInput(
+                expression = mapOf(
+                    "distinct" to listOf("a", 3, "c")
                 ),
                 result = Success(listOf("a", 3, "c"))
             ),

--- a/operations-stdlib/src/commonTest/kotlin/array/JoinToStringTest.kt
+++ b/operations-stdlib/src/commonTest/kotlin/array/JoinToStringTest.kt
@@ -26,13 +26,11 @@ class JoinToStringTest : FunSpec({
                     operationName to listOf(
                         mapOf(
                             "distinct" to listOf(
-                                listOf(
                                     "strawberry",
                                     "apple",
                                     "banana",
                                     "banana",
                                     "pineapple"
-                                )
                             )
                         ), " + ", "add some: ", " and mix!", 3, "random fruits"
                     )
@@ -60,7 +58,7 @@ class JoinToStringTest : FunSpec({
             TestInput(
                 expression = mapOf(
                     operationName to listOf(
-                        mapOf("distinct" to listOf(mapOf("var" to "fruits"))),
+                        mapOf("distinct" to mapOf("var" to "fruits")),
                         " + ",
                         "add some: ",
                         " and mix!",

--- a/operations-stdlib/src/commonTest/kotlin/array/SizeTest.kt
+++ b/operations-stdlib/src/commonTest/kotlin/array/SizeTest.kt
@@ -15,6 +15,9 @@ class SizeTest : FunSpec({
             TestInput(
                 expression = mapOf("size" to listOf(listOf("test"))),
                 result = JsonLogicResult.Success(1)
+            ),TestInput(
+                expression = mapOf("size" to listOf(true, "hello", "world", "!", 3)),
+                result = JsonLogicResult.Success(5)
             ),
             TestInput(
                 expression = mapOf("size" to listOf(listOf("test", "test2"), "a")),
@@ -28,14 +31,14 @@ class SizeTest : FunSpec({
                     )
                 ),
                 data = mapOf("fruits" to listOf(listOf("apple"), "banana", "pineapple"), "fruits2" to "testFruit"),
-                result = JsonLogicResult.Success(3)
+                result = JsonLogicResult.Success(2)
             ),
             TestInput(
                 expression = mapOf(
                     "size" to mapOf("var" to "fruits")
                 ),
                 data = mapOf("fruits" to listOf(listOf(listOf("apple"), "banana", "pineapple"))),
-                result = JsonLogicResult.Success(3)
+                result = JsonLogicResult.Success(1)
             ),
             TestInput(
                 expression = mapOf(
@@ -50,11 +53,11 @@ class SizeTest : FunSpec({
                     )
                 ),
                 data = mapOf("temp" to 55),
-                result = JsonLogicResult.Success(4)
+                result = JsonLogicResult.Success(1)
             ),
             TestInput(
                 expression = mapOf("size" to listOf<Any>(listOf<Any>())),
-                result = JsonLogicResult.Success(0)
+                result = JsonLogicResult.Success(1)
             ),
             TestInput(
                 expression = mapOf(
@@ -67,7 +70,7 @@ class SizeTest : FunSpec({
                     )
                 ),
                 data = mapOf("temp" to 55),
-                result = JsonLogicResult.Failure.NullResult
+                result = JsonLogicResult.Success(4)
             ),
             TestInput(
                 expression = mapOf(
@@ -86,6 +89,12 @@ class SizeTest : FunSpec({
                     "size" to null
                 ),
                 result = JsonLogicResult.Failure.NullResult
+            ),
+            TestInput(
+                expression = mapOf(
+                    "size" to emptyList<Any>()
+                ),
+                result = JsonLogicResult.Success(0)
             ),
             TestInput(
                 expression = mapOf(

--- a/operations-stdlib/src/commonTest/kotlin/array/SortTest.kt
+++ b/operations-stdlib/src/commonTest/kotlin/array/SortTest.kt
@@ -56,11 +56,11 @@ class SortTest : FunSpec({
             ),
             TestInput(
                 expression = mapOf(operatorName to listOf(0, "desc")),
-                result = Success(listOf(0.0))
+                result = Failure.NullResult
             ),
             TestInput(
                 expression = mapOf(operatorName to listOf(0, 1, 2 , 3, "desc")),
-                result = Success(listOf(0.0))
+                result = Failure.NullResult
             ),
             TestInput(
                 expression = mapOf(operatorName to listOf(listOf(0.01, 0.01, 0.001), "desc")),

--- a/operations-stdlib/src/commonTest/kotlin/array/SortTest.kt
+++ b/operations-stdlib/src/commonTest/kotlin/array/SortTest.kt
@@ -59,6 +59,10 @@ class SortTest : FunSpec({
                 result = Success(listOf(0.0))
             ),
             TestInput(
+                expression = mapOf(operatorName to listOf(0, 1, 2 , 3, "desc")),
+                result = Success(listOf(0.0))
+            ),
+            TestInput(
                 expression = mapOf(operatorName to listOf(listOf(0.01, 0.01, 0.001), "desc")),
                 result = Success(listOf(0.01, 0.01, 0.001))
             ),


### PR DESCRIPTION
## What:
<!--- Describe your changes in detail. -->
* Operation input autowrapping removal from the evaluation code. Any arguments wrapping is now done by operators themselves.

## Why:
<!--- Why is this change required? What problem does it solve? -->
* To simplify input interpretation, mainly in stdlib module. Now dveloper is able to distinct if an operation input is some single argument, a collection or something else. 

## Example:
<!--- Share some code snippets to show the idea in action. -->
* See modified and additional unit tests to spot the difference
https://github.com/allegro/json-logic-kmp/compare/disable-args-autowrapping?expand=1#diff-51f3acd2de6d199d171f8a3c7233226bebf589c5bf5fb6e84f7219f47e3afedfR19