### PR TITLE
Normalized double result

### DIFF
--- a/core/src/commonMain/kotlin/CommonJsonLogicEngine.kt
+++ b/core/src/commonMain/kotlin/CommonJsonLogicEngine.kt
@@ -14,6 +14,11 @@ internal class CommonJsonLogicEngine(private val evaluator: LogicEvaluator) : Js
     )
 
     private fun toJsonLogicResult(evaluatedValue: Any?) = evaluatedValue?.let { notNullResult ->
-        JsonLogicResult.Success(notNullResult)
+        JsonLogicResult.Success(notNullResult.toNormalizedResult())
     } ?: JsonLogicResult.Failure.NullResult
+
+    private fun Any.toNormalizedResult() =
+        if (this is Double && this.mod(1.0) == 0.0) {
+            this.toLong()
+        } else this
 }

--- a/core/src/commonTest/kotlin/operations/numeric/AdditionTest.kt
+++ b/core/src/commonTest/kotlin/operations/numeric/AdditionTest.kt
@@ -74,6 +74,14 @@ class AdditionTest : FunSpec({
                 result = JsonLogicResult.Success(9.99999)
             ),
             TestInput(
+                expression = mapOf("+" to listOf(Int.MAX_VALUE, 3)),
+                result = JsonLogicResult.Success(Int.MAX_VALUE + 3L)
+            ),
+            TestInput(
+                expression = mapOf("+" to listOf(Int.MIN_VALUE, -3)),
+                result = JsonLogicResult.Success(Int.MIN_VALUE - 3L)
+            ),
+            TestInput(
                 expression = mapOf("+" to listOf(listOf(2, 2), 2)),
                 result = JsonLogicResult.Success(4)
             ),

--- a/core/src/commonTest/kotlin/operations/numeric/DivisionTest.kt
+++ b/core/src/commonTest/kotlin/operations/numeric/DivisionTest.kt
@@ -77,6 +77,14 @@ class DivisionTest : FunSpec({
                 expression = mapOf("/" to listOf(emptyList<String>(), 2)),
                 result = JsonLogicResult.Success(0)
             ),
+            TestInput(
+                expression = mapOf("/" to listOf(Int.MAX_VALUE + 3L, 2)),
+                result = JsonLogicResult.Success((Int.MAX_VALUE + 3L) / 2)
+            ),
+            TestInput(
+                expression = mapOf("/" to listOf(Int.MIN_VALUE - 3L, 2)),
+                result = JsonLogicResult.Success((Int.MIN_VALUE - 3L) / 2.0)
+            ),
             TestInput(expression = mapOf("/" to listOf("1", "0")), result = JsonLogicResult.Failure.NullResult),
             TestInput(expression = mapOf("/" to listOf("1", 0)), result = JsonLogicResult.Failure.NullResult),
             TestInput(

--- a/core/src/commonTest/kotlin/operations/numeric/MaxTest.kt
+++ b/core/src/commonTest/kotlin/operations/numeric/MaxTest.kt
@@ -34,16 +34,24 @@ class MaxTest : FunSpec({
                 result = JsonLogicResult.Success(1)
             ),
             TestInput(
+                expression = mapOf("max" to listOf(1, "2")),
+                result = JsonLogicResult.Success(2)
+            ),
+            TestInput(
+                expression = mapOf("max" to listOf(Int.MIN_VALUE - 1L, Int.MIN_VALUE, 0)),
+                result = JsonLogicResult.Success(0)
+            ),
+            TestInput(
+                expression = mapOf("max" to listOf(Int.MAX_VALUE + 1L, Int.MAX_VALUE, 0)),
+                result = JsonLogicResult.Success(Int.MAX_VALUE + 1L)
+            ),
+            TestInput(
                 expression = mapOf("max" to listOf(1, "banana")),
                 result = JsonLogicResult.Failure.NullResult
             ),
             TestInput(
                 expression = mapOf("max" to listOf(1, "banana", listOf(1, 2))),
                 result = JsonLogicResult.Failure.NullResult
-            ),
-            TestInput(
-                expression = mapOf("max" to listOf(1, "2")),
-                result = JsonLogicResult.Success(2)
             ),
         )
         // given

--- a/core/src/commonTest/kotlin/operations/numeric/MinTest.kt
+++ b/core/src/commonTest/kotlin/operations/numeric/MinTest.kt
@@ -42,6 +42,14 @@ class MinTest : FunSpec({
                 result = JsonLogicResult.Success(1)
             ),
             TestInput(
+                expression = mapOf("min" to listOf(Int.MIN_VALUE - 1L, Int.MIN_VALUE, 0)),
+                result = JsonLogicResult.Success(Int.MIN_VALUE - 1L)
+            ),
+            TestInput(
+                expression = mapOf("min" to listOf(Int.MAX_VALUE + 1L, Int.MAX_VALUE, 0)),
+                result = JsonLogicResult.Success(0)
+            ),
+            TestInput(
                 expression = mapOf("min" to listOf(1, "banana")),
                 result = JsonLogicResult.Failure.NullResult
             ),

--- a/core/src/commonTest/kotlin/operations/numeric/ModuloTest.kt
+++ b/core/src/commonTest/kotlin/operations/numeric/ModuloTest.kt
@@ -82,6 +82,14 @@ class ModuloTest : FunSpec({
                 result = JsonLogicResult.Success(5)
             ),
             TestInput(
+                expression = mapOf("%" to listOf(Int.MAX_VALUE + 3L, 3)),
+                result = JsonLogicResult.Success((Int.MAX_VALUE + 3L).mod(3))
+            ),
+            TestInput(
+                expression = mapOf("%" to listOf(Int.MIN_VALUE - 3L, -3)),
+                result = JsonLogicResult.Success((Int.MIN_VALUE - 3L).mod(-3))
+            ),
+            TestInput(
                 expression = mapOf("%" to listOf(listOf(listOf("5"), listOf(6)))),
                 result = JsonLogicResult.Failure.NullResult
             ),

--- a/core/src/commonTest/kotlin/operations/numeric/MultiplicationTest.kt
+++ b/core/src/commonTest/kotlin/operations/numeric/MultiplicationTest.kt
@@ -94,6 +94,14 @@ class MultiplicationTest : FunSpec({
                 result = JsonLogicResult.Success(listOf(listOf("5"), listOf(6)))
             ),
             TestInput(
+                expression = mapOf("*" to listOf(Int.MAX_VALUE, 3)),
+                result = JsonLogicResult.Success(Int.MAX_VALUE * 3L)
+            ),
+            TestInput(
+                expression = mapOf("*" to listOf(Int.MIN_VALUE, -3)),
+                result = JsonLogicResult.Success(Int.MIN_VALUE * -3L)
+            ),
+            TestInput(
                 expression = mapOf("*" to listOf(emptyList<String>(), 2)),
                 result = JsonLogicResult.Failure.NullResult
             ),

--- a/core/src/commonTest/kotlin/operations/numeric/SubtractionTest.kt
+++ b/core/src/commonTest/kotlin/operations/numeric/SubtractionTest.kt
@@ -114,6 +114,14 @@ class SubtractionTest : FunSpec({
                 result = JsonLogicResult.Success(-2)
             ),
             TestInput(
+                expression = mapOf("-" to listOf(Int.MAX_VALUE, -3)),
+                result = JsonLogicResult.Success(Int.MAX_VALUE + 3L)
+            ),
+            TestInput(
+                expression = mapOf("-" to listOf(Int.MIN_VALUE, 3)),
+                result = JsonLogicResult.Success(Int.MIN_VALUE - 3L)
+            ),
+            TestInput(
                 expression = mapOf("-" to emptyList<Double>()),
                 result = JsonLogicResult.Failure.NullResult
             ),

--- a/core/src/commonTest/kotlin/operations/numeric/SubtractionTest.kt
+++ b/core/src/commonTest/kotlin/operations/numeric/SubtractionTest.kt
@@ -43,7 +43,7 @@ class SubtractionTest : FunSpec({
             ),
             TestInput(
                 expression = mapOf("-" to listOf("1", 1, listOf("banana"))),
-                result = JsonLogicResult.Success(0.0)
+                result = JsonLogicResult.Success(0)
             ),
             TestInput(
                 expression = mapOf("-" to listOf(listOf("5"), listOf("5"), listOf("5"))),

--- a/core/src/commonTest/kotlin/operations/numeric/compare/GreaterThanOrEqualToTest.kt
+++ b/core/src/commonTest/kotlin/operations/numeric/compare/GreaterThanOrEqualToTest.kt
@@ -146,6 +146,14 @@ class GreaterThanOrEqualToTest : FunSpec({
                 expression = mapOf(">=" to listOf("banana", 2)),
                 result = JsonLogicResult.Success(false)
             ),
+            TestInput(
+                expression = mapOf(">=" to listOf(Int.MAX_VALUE + 3L, 0)),
+                result = JsonLogicResult.Success(true)
+            ),
+            TestInput(
+                expression = mapOf(">=" to listOf(Int.MIN_VALUE - 3L, 0)),
+                result = JsonLogicResult.Success(false)
+            ),
         )
         // given
     ) { testInput: TestInput ->

--- a/core/src/commonTest/kotlin/operations/numeric/compare/GreaterThanTest.kt
+++ b/core/src/commonTest/kotlin/operations/numeric/compare/GreaterThanTest.kt
@@ -138,6 +138,14 @@ class GreaterThanTest : FunSpec({
                 expression = mapOf(">" to listOf(false, "false")),
                 result = JsonLogicResult.Success(false)
             ),
+            TestInput(
+                expression = mapOf(">" to listOf(Int.MAX_VALUE + 3L, 0)),
+                result = JsonLogicResult.Success(true)
+            ),
+            TestInput(
+                expression = mapOf(">" to listOf(Int.MIN_VALUE - 3L, 0)),
+                result = JsonLogicResult.Success(false)
+            ),
         )
         // given
     ) { testInput: TestInput ->

--- a/core/src/commonTest/kotlin/operations/numeric/compare/LessThanOrEqualToTest.kt
+++ b/core/src/commonTest/kotlin/operations/numeric/compare/LessThanOrEqualToTest.kt
@@ -122,6 +122,14 @@ class LessThanOrEqualToTest : FunSpec({
                 expression = mapOf("<=" to listOf(false, "false")),
                 result = JsonLogicResult.Success(false)
             ),
+            TestInput(
+                expression = mapOf("<=" to listOf(Int.MAX_VALUE + 3L, 0)),
+                result = JsonLogicResult.Success(false)
+            ),
+            TestInput(
+                expression = mapOf("<=" to listOf(Int.MIN_VALUE - 3L, 0)),
+                result = JsonLogicResult.Success(true)
+            ),
         )
         // given
     ) { testInput: TestInput ->

--- a/core/src/commonTest/kotlin/operations/numeric/compare/LessThanTest.kt
+++ b/core/src/commonTest/kotlin/operations/numeric/compare/LessThanTest.kt
@@ -126,6 +126,14 @@ class LessThanTest : FunSpec({
                 expression = mapOf("<" to listOf(false, "false")),
                 result = JsonLogicResult.Success(false)
             ),
+            TestInput(
+                expression = mapOf("<" to listOf(Int.MAX_VALUE + 3L, 0)),
+                result = JsonLogicResult.Success(false)
+            ),
+            TestInput(
+                expression = mapOf("<" to listOf(Int.MIN_VALUE - 3L, 0)),
+                result = JsonLogicResult.Success(true)
+            ),
         )
         // given
     ) { testInput: TestInput ->


### PR DESCRIPTION
## What:
<!--- Describe your changes in detail. -->
* When logic result is of type Double and is a whole number it will be cast to Long

## Why:
<!--- Why is this change required? What problem does it solve? -->
* To be consistent with [JsonLogic](https://jsonlogic.com/operations.html)
<img width="738" alt="image" src="https://user-images.githubusercontent.com/33655552/201661027-93d3f376-67b8-4feb-b273-76c8513fec7a.png">
