### PR TITLE
Bump kotlin to 1.8.0, Set bundle id for iOS

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -6,6 +6,7 @@ object LibConfig {
     const val name = "JsonLogicKMP"
     const val artifactName = "json-logic"
     const val xcFrameworkName = "JsonLogicKMP"
+    const val bundleId = "pl.allegro.mobile.JsonLogicKMP"
 }
 
 object Modules {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,4 @@
 kotlin.code.style=official
-kotlin.mpp.enableGranularSourceSetsMetadata=true
-kotlin.native.enableDependencyPropagation=false
 kotlin.mpp.stability.nowarn=true
 org.gradle.jvmargs=-Xmx2560m
 org.gradle.daemon=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,9 @@
 axion = "1.14.0"
 detekt = "1.19.0"
 nexus = "1.0.0"
-kotest = "5.0.2"
+kotest = "5.5.4"
 crashkios = "0.4.0"
-kotlin = "1.6.20"
+kotlin = "1.8.0"
 
 [libraries]
 axion-release = { module = "pl.allegro.tech.build:axion-release-plugin", version.ref = "axion" }

--- a/umbrella-framework/build.gradle.kts
+++ b/umbrella-framework/build.gradle.kts
@@ -23,6 +23,7 @@ kotlin {
         iosSimulatorArm64()
     ).forEach {
         it.binaries.framework {
+            binaryOption("bundleId", LibConfig.bundleId)
             baseName = LibConfig.xcFrameworkName
             isStatic = true
             export(project(Modules.core))


### PR DESCRIPTION
## What:
<!--- Describe your changes in detail. -->
* bump kotlin to 1.8.0
* set bundle id for iOS

## Why:
<!--- Why is this change required? What problem does it solve? -->
* https://kotlinlang.org/docs/whatsnew1720.html#the-new-kotlin-native-memory-manager-enabled-by-default

