### PR TITLE
Add string split operator

### DIFF
--- a/operations-stdlib/src/commonMain/kotlin/OperationsProvider.kt
+++ b/operations-stdlib/src/commonMain/kotlin/OperationsProvider.kt
@@ -17,6 +17,7 @@ import string.ToArray
 import string.Trim
 import string.Uppercase
 import string.Match
+import string.Split
 
 object OperationsProvider {
     val standardOperations: Map<String, StandardLogicOperation> = mutableMapOf(
@@ -32,6 +33,7 @@ object OperationsProvider {
         "encode" to Encode,
         "match" to Match,
         "compareToDate" to CompareToDate,
+        "split" to Split,
 
         // time
         "currentTime" to CurrentTimeMillis,

--- a/operations-stdlib/src/commonMain/kotlin/string/Split.kt
+++ b/operations-stdlib/src/commonMain/kotlin/string/Split.kt
@@ -1,0 +1,35 @@
+package string
+
+import operation.StandardLogicOperation
+import utils.asList
+
+object Split : StandardLogicOperation {
+    private const val TEXT_ARG_INDEX = 0
+    private const val DELIMITERS_ARG_INDEX = 1
+
+    override fun evaluateLogic(expression: Any?, data: Any?): Any? =
+        expression.asList.toOperationArguments()?.invokeSplit()
+
+    private fun List<Any?>.toOperationArguments(): SplitArguments? = runCatching {
+        SplitArguments(
+            text = get(TEXT_ARG_INDEX) as String,
+            delimiters = get(DELIMITERS_ARG_INDEX) as List<Any?>
+        )
+    }.fold(
+        onSuccess = { it },
+        onFailure = { null }
+    )
+
+    private fun SplitArguments.invokeSplit(): List<String> {
+        val convertedDelimiters = delimiters
+            .map { it as String }
+            .toSet()
+            .toTypedArray()
+       return text.split(delimiters = convertedDelimiters)
+    }
+}
+
+private data class SplitArguments(
+    var text: String,
+    val delimiters: List<Any?>
+)

--- a/operations-stdlib/src/commonTest/kotlin/string/SplitTest.kt
+++ b/operations-stdlib/src/commonTest/kotlin/string/SplitTest.kt
@@ -1,0 +1,90 @@
+package string
+
+import TestInput
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import JsonLogicResult.Success
+import JsonLogicResult.Failure
+
+class SplitTest : FunSpec({
+    val operatorName = "split"
+    val logicEngine = JsonLogicEngine.Builder().addStandardOperation(operatorName, Split).build()
+
+    withData(
+        nameFn = { input -> "Should evaluated ${input.expression} with given ${input.data} result in ${input.result}" },
+        ts = listOf(
+            TestInput(
+                expression = mapOf(operatorName to listOf("one,two,three", listOf(","))),
+                result = Success(listOf("one", "two", "three"))
+            ),
+            TestInput(
+                expression = mapOf(operatorName to listOf("one, two, three", listOf(","))),
+                result = Success(listOf("one", " two", " three"))
+            ),
+            TestInput(
+                expression = mapOf(operatorName to listOf("one, two, three", listOf(", "))),
+                result = Success(listOf("one", "two", "three"))
+            ),
+            TestInput(
+                expression = mapOf(operatorName to listOf("/location/to/file", listOf("/"))),
+                result = Success(listOf("", "location", "to", "file"))
+            ),
+            TestInput(
+                expression = mapOf(operatorName to listOf("location\\to\\file", listOf("\\"))),
+                result = Success(listOf("location", "to", "file"))
+            ),
+            TestInput(
+                expression = mapOf(operatorName to listOf("oneAtwoAthree", listOf("A"))),
+                result = Success(listOf("one", "two", "three"))
+            ),
+            TestInput(
+                expression = mapOf(operatorName to listOf("The quick brown fox jumps over the lazy dog", listOf(" "))),
+                result = Success(listOf("The", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"))
+            ),
+            TestInput(
+                expression = mapOf(operatorName to listOf("https://domain.net/query/search", listOf("/"))),
+                result = Success(listOf("https:", "", "domain.net", "query", "search"))
+            ),
+            TestInput(
+                expression = mapOf(operatorName to listOf("Hello", listOf(""))),
+                result = Success(listOf("", "H", "e", "l", "l", "o", ""))
+            ),
+            TestInput(
+                expression = mapOf(operatorName to listOf("", listOf(""))),
+                result = Success(listOf("", ""))
+            ),
+            TestInput(
+                expression = mapOf(operatorName to listOf(null, null)),
+                result = Failure.NullResult
+            ),
+            TestInput(
+                expression = mapOf(operatorName to listOf(null, ",")),
+                result = Failure.NullResult
+            ),
+            TestInput(
+                expression = mapOf(operatorName to listOf("Hello", "")),
+                result = Failure.NullResult
+            ),
+            TestInput(
+                expression = mapOf(operatorName to listOf("Hello", 1)),
+                result = Failure.NullResult
+            ),
+            TestInput(
+                expression = mapOf(operatorName to listOf("Hello", true)),
+                result = Failure.NullResult
+            ),
+            TestInput(
+                expression = mapOf(operatorName to listOf("Hello", listOf(0, 1))),
+                result = Failure.MissingOperation
+            ),
+        )
+        // given
+    ) { testInput: TestInput ->
+        // when
+        val evaluationResult = logicEngine.evaluate(testInput.expression, testInput.data)
+
+        // then
+        evaluationResult shouldBe testInput.result
+    }
+})


### PR DESCRIPTION
## What:
* Added new Split operator for String.

## Why:
* Missing functionality.

## Example:
* `"one,two,three".split(",")` -> `["one", "two", "three"]`
